### PR TITLE
fix: add TypeScript declarations for react-dom/client module

### DIFF
--- a/src/react-dom-client.d.ts
+++ b/src/react-dom-client.d.ts
@@ -1,0 +1,16 @@
+declare module 'react-dom/client' {
+  import { ReactNode } from 'react';
+
+  export interface Root {
+    render(children: ReactNode): void;
+    unmount(): void;
+  }
+
+  export interface RootOptions {
+    identifierPrefix?: string;
+    onRecoverableError?: (error: unknown, errorInfo: { digest?: string }) => void;
+  }
+
+  export function createRoot(container: Element | DocumentFragment, options?: RootOptions): Root;
+  export function hydrateRoot(container: Element | Document, initialChildren: ReactNode, options?: RootOptions): Root;
+}


### PR DESCRIPTION
## Summary
- Add explicit TypeScript declarations for `react-dom/client` module
- Resolves TS7016 error that was causing CI builds to fail
- Provides proper typing for `createRoot` and `hydrateRoot` functions

## Problem
The CI environment was unable to find TypeScript declarations for the `react-dom/client` module, even though `@types/react-dom` was installed. This caused the following error:
```
Error: src/index.tsx(1,28): error TS7016: Could not find a declaration file for module 'react-dom/client'
```

## Solution
Created a custom TypeScript declaration file (`src/react-dom-client.d.ts`) that explicitly declares the module and its exports. This ensures the TypeScript compiler can properly resolve the module in all environments.

## Test plan
- [x] TypeScript compilation passes locally (`npx tsc --noEmit`)
- [x] Build process completes successfully (`npm run build`)
- [x] Verify CI passes with the new declaration file

🤖 Generated with [Claude Code](https://claude.ai/code)