### PR TITLE
fix: resolve ESLint dependency issue in GitHub Actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",
-    "lint": "npx eslint src --ext .ts,.tsx",
+    "lint": "eslint src --ext .ts,.tsx",
     "preview": "vite preview"
   },
   "browserslist": {


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions deploy failure by changing lint script to use locally installed ESLint instead of npx
- The issue was that `npx eslint` tries to install ESLint globally and cannot access devDependencies like `@eslint/js`
- Changed `"lint": "npx eslint src --ext .ts,.tsx"` to `"lint": "eslint src --ext .ts,.tsx"`

## Test plan
- [x] Tested locally that `npm run lint` works correctly
- [ ] Verify GitHub Actions deploy passes after merge

🤖 Generated with [Claude Code](https://claude.ai/code)