### PR TITLE
fix: use local binaries instead of npx to prevent global downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",
-    "lint": "npx eslint src --ext .ts,.tsx",
-    "typecheck": "npx tsc --noEmit",
+    "lint": "./node_modules/.bin/eslint src --ext .ts,.tsx",
+    "typecheck": "./node_modules/.bin/tsc --noEmit",
     "preview": "vite preview"
   },
   "browserslist": {


### PR DESCRIPTION
## Summary
- Changed lint and typecheck scripts to use direct paths to local binaries (`./node_modules/.bin/`)
- Prevents npx from downloading global packages when local ones exist but aren't found in PATH
- Fixes "Cannot find package 'typescript-eslint'" errors in GitHub Actions

## Root Cause
The issue was that `npx eslint` would sometimes download ESLint globally instead of using the local installation, and the global version couldn't access our project's `typescript-eslint` dependency.

## Test plan
- [x] Tested locally that `npm run lint` works correctly  
- [x] Tested locally that `npm run typecheck` works correctly
- [ ] Verify GitHub Actions deploy passes after merge

## Changes
- `"lint": "npx eslint..."` → `"lint": "./node_modules/.bin/eslint..."`
- `"typecheck": "npx tsc..."` → `"typecheck": "./node_modules/.bin/tsc..."`

🤖 Generated with [Claude Code](https://claude.ai/code)