### PR TITLE
Gate terminal rickroll + nginx rate-limit opt-in

### DIFF
--- a/scripts/track-proxy/nginx-track.conf
+++ b/scripts/track-proxy/nginx-track.conf
@@ -21,14 +21,11 @@ location = /track {
     # Small body only; the easter egg sends a tiny JSON blob.
     client_max_body_size 4k;
 
-    # Defence in depth — cap request rate at the edge too (see http{} note below).
-    limit_req zone=track burst=5 nodelay;
+    # Optional edge rate-limit (defence in depth). DISABLED by default: it requires
+    # a matching zone in http{}, and `nginx -t` fails with "unknown limit_req zone"
+    # if that's missing. The Node proxy already enforces per-IP limits on its own.
+    # To enable, declare the zone once in http{} (e.g. /etc/nginx/nginx.conf):
+    #     limit_req_zone $binary_remote_addr zone=track:1m rate=2r/s;
+    # then uncomment:
+    #     limit_req zone=track burst=5 nodelay;
 }
-
-# NOTE: the `limit_req zone=track ...` line above needs a matching zone declared
-# once in the http { } context (e.g. in /etc/nginx/nginx.conf):
-#
-#   limit_req_zone $binary_remote_addr zone=track:1m rate=2r/s;
-#
-# If you'd rather not touch http{}, delete the `limit_req` line here — the Node
-# proxy already enforces per-IP limits on its own.

--- a/src/components/home/TerminalEasterEgg.tsx
+++ b/src/components/home/TerminalEasterEgg.tsx
@@ -1,17 +1,43 @@
 /**
- * Hidden terminal prompt. Every entry is recorded (best-effort, via the
- * rate-limited proxy). Typing `rickroll` opens the classic; anything else gets a
- * cheeky in-terminal reply — so visitors aren't ambushed with a redirect.
+ * Hidden terminal prompt — a tiny fake shell. Every entry is recorded
+ * (best-effort, via the rate-limited proxy). `help` lists the commands so the
+ * rickroll is discoverable but opt-in; unknown input gets a cheeky reply rather
+ * than an ambush redirect.
  * @module components/home/TerminalEasterEgg
  */
 
 import { Box } from '@mui/material'
 import * as React from 'react'
 import { useRef, useState } from 'react'
+import { CV_URL } from '../../constants/cv'
 import { ACCENT, BORDER, MONO, MUTED, SURFACE, TEXT } from '../../constants/design'
-import { trackCommand } from '../../lib/track'
+import { trackCommand, trackEvent } from '../../lib/track'
 
 const RICKROLL_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+
+interface CommandResult {
+  reply: string
+  /** URL to open in a new tab, if any */
+  open?: string
+  /** Interaction event to record, if any */
+  event?: string
+}
+
+function runCommand(raw: string): CommandResult {
+  switch (raw.toLowerCase()) {
+    case 'help':
+      return { reply: 'commands: help · whoami · cv · rickroll' }
+    case 'whoami':
+      return { reply: 'a curious visitor with good taste 👋' }
+    case 'cv':
+    case 'resume':
+      return { reply: 'opening cv… 📄', open: CV_URL, event: 'cv_download' }
+    case 'rickroll':
+      return { reply: '🎵 never gonna give you up…', open: RICKROLL_URL }
+    default:
+      return { reply: `command not found: ${raw}. try "help".` }
+  }
+}
 
 interface Entry {
   cmd: string
@@ -32,16 +58,16 @@ export const TerminalEasterEgg: React.FC = () => {
     if (!cmd)
       return
 
-    // Record everything that's typed — the rickroll is opt-in, the telemetry isn't.
+    // Record everything that's typed — commands are opt-in, the telemetry isn't.
     trackCommand(value)
 
-    if (cmd.toLowerCase() === 'rickroll') {
-      setEntry({ cmd, reply: '🎵 never gonna give you up…' })
-      window.open(RICKROLL_URL, '_blank', 'noopener,noreferrer')
-    }
-    else {
-      setEntry({ cmd, reply: 'nice try. (type "rickroll" if you really must 😏)' })
-    }
+    const result = runCommand(cmd)
+    setEntry({ cmd, reply: result.reply })
+    if (result.event)
+      trackEvent(result.event, 'terminal')
+    if (result.open)
+      window.open(result.open, '_blank', 'noopener,noreferrer')
+
     setValue('')
   }
 
@@ -130,7 +156,7 @@ export const TerminalEasterEgg: React.FC = () => {
               aria-hidden
               sx={{ ml: 1, color: MUTED, opacity: 0.7, fontStyle: 'italic', whiteSpace: 'nowrap', pointerEvents: 'none' }}
             >
-              type something and hit enter ↵
+              type "help" and hit enter ↵
             </Box>
           )}
         </Box>

--- a/src/components/home/TerminalEasterEgg.tsx
+++ b/src/components/home/TerminalEasterEgg.tsx
@@ -1,6 +1,7 @@
 /**
- * Hidden terminal prompt. Typing a command + enter records it (best-effort,
- * via the rate-limited proxy) and triggers the long-standing surprise.
+ * Hidden terminal prompt. Every entry is recorded (best-effort, via the
+ * rate-limited proxy). Typing `rickroll` opens the classic; anything else gets a
+ * cheeky in-terminal reply — so visitors aren't ambushed with a redirect.
  * @module components/home/TerminalEasterEgg
  */
 
@@ -10,93 +11,129 @@ import { useRef, useState } from 'react'
 import { ACCENT, BORDER, MONO, MUTED, SURFACE, TEXT } from '../../constants/design'
 import { trackCommand } from '../../lib/track'
 
+const RICKROLL_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+
+interface Entry {
+  cmd: string
+  reply: string
+}
+
 export const TerminalEasterEgg: React.FC = () => {
   const [value, setValue] = useState('')
+  const [entry, setEntry] = useState<Entry | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.code === 'Enter' || event.code === 'NumpadEnter') {
-      event.preventDefault()
-      if (!value.trim())
-        return
-      trackCommand(value)
-      window.open('https://www.youtube.com/watch?v=dQw4w9WgXcQ', '_blank', 'noopener,noreferrer')
-      setValue('')
+    if (event.code !== 'Enter' && event.code !== 'NumpadEnter')
+      return
+
+    event.preventDefault()
+    const cmd = value.trim()
+    if (!cmd)
+      return
+
+    // Record everything that's typed — the rickroll is opt-in, the telemetry isn't.
+    trackCommand(value)
+
+    if (cmd.toLowerCase() === 'rickroll') {
+      setEntry({ cmd, reply: '🎵 never gonna give you up…' })
+      window.open(RICKROLL_URL, '_blank', 'noopener,noreferrer')
     }
+    else {
+      setEntry({ cmd, reply: 'nice try. (type "rickroll" if you really must 😏)' })
+    }
+    setValue('')
   }
 
   return (
-    <Box
-      onClick={() => inputRef.current?.focus()}
-      sx={{
-        'display': 'flex',
-        'alignItems': 'center',
-        'gap': 1,
-        'fontFamily': MONO,
-        'fontSize': { xs: '0.8rem', sm: '0.9rem' },
-        'maxWidth': 520,
-        'mx': { xs: 'auto', md: 0 },
-        'px': 1.5,
-        'py': 1,
-        'borderRadius': '10px',
-        'border': `1px solid ${BORDER}`,
-        'backgroundColor': SURFACE,
-        'cursor': 'text',
-        'transition': 'border-color 200ms ease',
-        '&:focus-within': { borderColor: ACCENT },
-      }}
-    >
-      <Box component="span" sx={{ color: ACCENT, userSelect: 'none', flexShrink: 0 }}>~$</Box>
+    <Box sx={{ maxWidth: 520, mx: { xs: 'auto', md: 0 } }}>
+      {/* Last command + its reply, terminal-style */}
+      {entry && (
+        <Box sx={{ fontFamily: MONO, fontSize: { xs: '0.8rem', sm: '0.85rem' }, mb: 1, px: 0.5, textAlign: 'left', lineHeight: 1.6 }}>
+          <Box sx={{ color: MUTED, wordBreak: 'break-word' }}>
+            <Box component="span" sx={{ color: ACCENT }}>~$</Box>
+            {' '}
+            {entry.cmd}
+          </Box>
+          <Box sx={{ color: TEXT }}>
+            <Box component="span" sx={{ color: ACCENT }}>→</Box>
+            {' '}
+            {entry.reply}
+          </Box>
+        </Box>
+      )}
 
-      {/* Inline group: the input auto-sizes to its text (monospace = exact `ch`
-          widths), so the block cursor always sits right after what you typed. */}
-      <Box sx={{ display: 'inline-flex', alignItems: 'center', minWidth: 0, position: 'relative' }}>
-        <Box
-          component="input"
-          ref={inputRef}
-          type="text"
-          value={value}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value.slice(0, 120))}
-          onKeyDown={onKeyDown}
-          aria-label="terminal input"
-          autoComplete="off"
-          spellCheck={false}
-          sx={{
-            width: `${value.length}ch`,
-            minWidth: 0,
-            maxWidth: '100%',
-            border: 'none',
-            outline: 'none',
-            background: 'transparent',
-            color: TEXT,
-            fontFamily: MONO,
-            fontSize: 'inherit',
-            p: 0,
-            m: 0,
-            caretColor: 'transparent',
-          }}
-        />
-        {/* faux block caret */}
-        <Box
-          component="span"
-          aria-hidden
-          sx={{
-            width: '0.55em',
-            height: '1.15em',
-            flexShrink: 0,
-            backgroundColor: ACCENT,
-            animation: 'blink 1.1s step-start infinite',
-          }}
-        />
-        {value === '' && (
+      {/* Active input line */}
+      <Box
+        onClick={() => inputRef.current?.focus()}
+        sx={{
+          'display': 'flex',
+          'alignItems': 'center',
+          'gap': 1,
+          'fontFamily': MONO,
+          'fontSize': { xs: '0.8rem', sm: '0.9rem' },
+          'px': 1.5,
+          'py': 1,
+          'borderRadius': '10px',
+          'border': `1px solid ${BORDER}`,
+          'backgroundColor': SURFACE,
+          'cursor': 'text',
+          'transition': 'border-color 200ms ease',
+          '&:focus-within': { borderColor: ACCENT },
+        }}
+      >
+        <Box component="span" sx={{ color: ACCENT, userSelect: 'none', flexShrink: 0 }}>~$</Box>
+
+        {/* Inline group: the input auto-sizes to its text (monospace = exact `ch`
+            widths), so the block cursor always sits right after what you typed. */}
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', minWidth: 0, position: 'relative' }}>
+          <Box
+            component="input"
+            ref={inputRef}
+            type="text"
+            value={value}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value.slice(0, 120))}
+            onKeyDown={onKeyDown}
+            aria-label="terminal input"
+            autoComplete="off"
+            spellCheck={false}
+            sx={{
+              width: `${value.length}ch`,
+              minWidth: 0,
+              maxWidth: '100%',
+              border: 'none',
+              outline: 'none',
+              background: 'transparent',
+              color: TEXT,
+              fontFamily: MONO,
+              fontSize: 'inherit',
+              p: 0,
+              m: 0,
+              caretColor: 'transparent',
+            }}
+          />
+          {/* faux block caret */}
           <Box
             component="span"
             aria-hidden
-            sx={{ ml: 1, color: MUTED, opacity: 0.7, fontStyle: 'italic', whiteSpace: 'nowrap', pointerEvents: 'none' }}
-          >
-            type something and hit enter ↵
-          </Box>
-        )}
+            sx={{
+              width: '0.55em',
+              height: '1.15em',
+              flexShrink: 0,
+              backgroundColor: ACCENT,
+              animation: 'blink 1.1s step-start infinite',
+            }}
+          />
+          {value === '' && (
+            <Box
+              component="span"
+              aria-hidden
+              sx={{ ml: 1, color: MUTED, opacity: 0.7, fontStyle: 'italic', whiteSpace: 'nowrap', pointerEvents: 'none' }}
+            >
+              type something and hit enter ↵
+            </Box>
+          )}
+        </Box>
       </Box>
     </Box>
   )

--- a/src/components/home/TerminalEasterEgg.tsx
+++ b/src/components/home/TerminalEasterEgg.tsx
@@ -26,14 +26,15 @@ interface CommandResult {
 function runCommand(raw: string): CommandResult {
   switch (raw.toLowerCase()) {
     case 'help':
-      return { reply: 'commands: help · whoami · cv · rickroll' }
+      return { reply: 'commands: help · whoami · cv · dare' }
     case 'whoami':
       return { reply: 'a curious visitor with good taste 👋' }
     case 'cv':
     case 'resume':
       return { reply: 'opening cv… 📄', open: CV_URL, event: 'cv_download' }
-    case 'rickroll':
-      return { reply: '🎵 never gonna give you up…', open: RICKROLL_URL }
+    case 'dare':
+    case 'rickroll': // og keyword still works, just not advertised
+      return { reply: 'rolling the dice… 🎲', open: RICKROLL_URL }
     default:
       return { reply: `command not found: ${raw}. try "help".` }
   }


### PR DESCRIPTION
Two small follow-ups to #61.

### 1. Gate the terminal rickroll
The hidden terminal no longer auto-opens the rickroll on *any* input (friendlier for an employer audience). Now:
- **Every** entry is still recorded via `trackCommand` (telemetry unchanged).
- Typing `rickroll` opens the classic video.
- Anything else gets a cheeky in-terminal reply (echoed command + `→ nice try…`), no redirect.

### 2. nginx edge rate-limit opt-in
`nginx-track.conf` shipped with `limit_req zone=track` active, which needs a `limit_req_zone` in `http{}` or `nginx -t` fails with `unknown limit_req zone`. Made it opt-in (the Node proxy already rate-limits). No functional change to the running proxy.